### PR TITLE
Small changes to improve compatibility.

### DIFF
--- a/md5.c
+++ b/md5.c
@@ -5,6 +5,9 @@
 
 #include "md5.h"
 
+#include <stdlib.h>
+#include <string.h>
+
 /*
  * Constants defined by the MD5 algorithm
  */

--- a/md5.c
+++ b/md5.c
@@ -81,7 +81,7 @@ void md5Init(MD5Context *ctx){
  * If the input fills out a block of 512 bits, apply the algorithm (md5Step)
  * and save the result in the buffer. Also updates the overall size.
  */
-void md5Update(MD5Context *ctx, uint8_t *input_buffer, size_t input_len){
+void md5Update(MD5Context *ctx, const uint8_t *input_buffer, size_t input_len){
     uint32_t input[16];
     unsigned int offset = ctx->size % 64;
     ctx->size += (uint64_t)input_len;
@@ -148,7 +148,7 @@ void md5Finalize(MD5Context *ctx){
 /*
  * Step on 512 bits of input with the main MD5 algorithm.
  */
-void md5Step(uint32_t *buffer, uint32_t *input){
+void md5Step(uint32_t *buffer, const uint32_t *input){
     uint32_t AA = buffer[0];
     uint32_t BB = buffer[1];
     uint32_t CC = buffer[2];
@@ -195,10 +195,10 @@ void md5Step(uint32_t *buffer, uint32_t *input){
  * Functions that run the algorithm on the provided input and put the digest into result.
  * result should be able to store 16 bytes.
  */
-void md5String(char *input, uint8_t *result){
+void md5String(const char *input, uint8_t *result){
     MD5Context ctx;
     md5Init(&ctx);
-    md5Update(&ctx, (uint8_t *)input, strlen(input));
+    md5Update(&ctx, (const uint8_t *)input, strlen(input));
     md5Finalize(&ctx);
 
     memcpy(result, ctx.digest, 16);

--- a/md5.h
+++ b/md5.h
@@ -3,8 +3,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
 
 typedef struct{
     uint64_t size;        // Size of input in bytes

--- a/md5.h
+++ b/md5.h
@@ -13,6 +13,10 @@ typedef struct{
     uint8_t digest[16];   // Result of algorithm
 }MD5Context;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void md5Init(MD5Context *ctx);
 void md5Update(MD5Context *ctx, const uint8_t *input, size_t input_len);
 void md5Finalize(MD5Context *ctx);
@@ -20,5 +24,9 @@ void md5Step(uint32_t *buffer, const uint32_t *input);
 
 void md5String(const char *input, uint8_t *result);
 void md5File(FILE *file, uint8_t *result);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/md5.h
+++ b/md5.h
@@ -14,11 +14,11 @@ typedef struct{
 }MD5Context;
 
 void md5Init(MD5Context *ctx);
-void md5Update(MD5Context *ctx, uint8_t *input, size_t input_len);
+void md5Update(MD5Context *ctx, const uint8_t *input, size_t input_len);
 void md5Finalize(MD5Context *ctx);
-void md5Step(uint32_t *buffer, uint32_t *input);
+void md5Step(uint32_t *buffer, const uint32_t *input);
 
-void md5String(char *input, uint8_t *result);
+void md5String(const char *input, uint8_t *result);
 void md5File(FILE *file, uint8_t *result);
 
 #endif


### PR DESCRIPTION
I added const qualifiers to all applicable function parameters. This helps in cases where the input buffer is only available through const qualified pointers.

I also added extern C to all function declarations so that the library can be accessed from C++ code.

As suggested in an issue, I moved some C standard library includes into the source file to avoid cluttering other translation units with unnecessary headers.

Closes #5 
Closes #6